### PR TITLE
Narrow public API and clean up some implementation

### DIFF
--- a/src/EnergyType.java
+++ b/src/EnergyType.java
@@ -1,0 +1,4 @@
+public enum EnergyType {
+    BACKWARD,
+    FORWARD
+}

--- a/src/GUI.java
+++ b/src/GUI.java
@@ -20,7 +20,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Random;
 
-public class GUI {
+public final class GUI {
     // Determines the range (0 - SLIDER) of values for the slider.
     public static volatile int SLIDER = 1000;
     // Color of the seams (if highlighting).

--- a/src/Main.java
+++ b/src/Main.java
@@ -6,7 +6,9 @@
 
 import java.io.File;
 
-public class Main {
+public final class Main {
+    private Main() {}
+
     public static final String SNAPSHOTS_DIR = "Snapshots";
 
     public static void main(String... args) {

--- a/src/SeamCarverBackward.java
+++ b/src/SeamCarverBackward.java
@@ -8,7 +8,7 @@ import java.util.List;
 /*
  * Implements the Seam Carving algorithm using backward energy.
  */
-public class SeamCarverBackward extends SeamCarverBase implements SeamCarver {
+public final class SeamCarverBackward extends SeamCarverBase implements SeamCarver {
 
     public SeamCarverBackward(int[][] image) {
         super(image);

--- a/src/SeamCarverBase.java
+++ b/src/SeamCarverBase.java
@@ -13,7 +13,7 @@ import java.util.Stack;
  * that are inherited by all children, which implement different carving
  * approaches.
  */
-public class SeamCarverBase {
+abstract class SeamCarverBase implements SeamCarver {
 
     // Height of the image.
     protected int height;

--- a/src/SeamCarverFactory.java
+++ b/src/SeamCarverFactory.java
@@ -5,11 +5,6 @@
 
 import java.io.File;
 
-enum EnergyType {
-    BACKWARD,
-    FORWARD
-}
-
 public class SeamCarverFactory {
 
     public SeamCarver create(File file, boolean horizontal, EnergyType type) {

--- a/src/SeamCarverFactory.java
+++ b/src/SeamCarverFactory.java
@@ -5,8 +5,7 @@
 
 import java.io.File;
 
-public class SeamCarverFactory {
-
+public final class SeamCarverFactory {
     public SeamCarver create(File file, boolean horizontal, EnergyType type) {
         return this.create(Utils.readImage(file), horizontal, type);
     }

--- a/src/SeamCarverForward.java
+++ b/src/SeamCarverForward.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 /*
  * Implements the Seam Carving algorithm using forward energy.
  */
-public class SeamCarverForward extends SeamCarverBase implements SeamCarver {
+public final class SeamCarverForward extends SeamCarverBase implements SeamCarver {
 
     // Used as a cache to keep track of the minimum error created by removing a seam.
     private final int[][] minimums;

--- a/src/Utils.java
+++ b/src/Utils.java
@@ -15,7 +15,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-public class Utils {
+public final class Utils {
+    private Utils() {}
+
     // Returns the minimum of "a", "b", and "c".
     public static int min(int a, int b, int c) {
         return (a < b) ? (a < c ? a : c) : (b < c ? b : c);

--- a/src/Utils.java
+++ b/src/Utils.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public final class Utils {
     private Utils() {}
@@ -49,22 +49,25 @@ public final class Utils {
      */
     public static void parallel(ParallelFunc func) {
         int cpus = Runtime.getRuntime().availableProcessors();
-
-        Thread[] threads = new Thread[cpus];
-        for (int i = 0; i < cpus; i++) {
-            int cpu = i;
-            threads[cpu] = new Thread(() -> func.process(cpu, cpus));
-        }
-
-        for (Thread thread : threads) {
-            thread.start();
-        }
-
+        ExecutorService executor = Executors.newFixedThreadPool(cpus);
         try {
-            for (Thread thread : threads) {
-                thread.join();
+            Future<?>[] tasks = new Future<?>[cpus];
+            for (int i = 0; i < cpus; i++) {
+                int cpu = i;
+                tasks[cpu] = executor.submit(() -> func.process(cpu, cpus));
             }
-        } catch (InterruptedException ignored) {}
+
+            for (Future<?> task : tasks) {
+                try {
+                    task.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+
     }
 
     /*


### PR DESCRIPTION
* Makes most classes final so as to reduce the public api surface of this as a library.
* Utils only has static methods, so hid its constructor
* Make SeamCarverBase non-public and abstract
* Instead of using `new Thread` directly, use an ExecutorService
* EnergyType is part of a public api but isn't a public class